### PR TITLE
Format equity metadata

### DIFF
--- a/equit_ease/displayer/display.py
+++ b/equit_ease/displayer/display.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from equit_ease.datatypes.equity_meta import EquityMeta
 from equit_ease.parser.parse import Parser
+from equit_ease.displayer.format import Formatter
+from equit_ease.utils.Constants import Constants
 
 
 class Displayer(Parser):
@@ -12,18 +14,25 @@ class Displayer(Parser):
 
     def __init__(self, equity_to_search, data):
         super().__init__(equity_to_search, data)
-
-    @staticmethod
-    def center_print(string_to_print: str) -> None:
+    
+    def set_formatting(self, value_to_format: str or int, formatting_type: str) -> str:
         """
-        center prints a string to the console.
+        apply a template of formatting to the provided value.
 
-        :param string_to_print -> ``str``: the string to print to the console.
-        :returns ``None``:
+        :param value_to_format -> ``str``: the value that should be formatted.
+        :param formatting_type -> ``str``: the type of formatting to perform.
+        :return result -> ``str``: the result to return.
         """
-        terminal_width, _ = os.get_terminal_size()
-        print(f"{string_to_print}".center(terminal_width))
-
+        result = value_to_format
+        
+        # https://stackoverflow.com/questions/1952464/in-python-how-do-i-determine-if-an-object-is-iterable
+        if isinstance(formatting_type, list):
+            for styling in formatting_type:
+                result = Constants.dispatcher[styling](result)
+        else:
+            result = Constants.dispatcher[formatting_type](result)
+        
+        return result
 
 class ChartDisplayer(Displayer):
     """"contains methods used solely for the displayment of the chart data."""
@@ -34,8 +43,7 @@ class QuoteDisplayer(Displayer):
 
     def stringify(self: QuoteDisplayer) -> str:
         """
-        str representation of the quote meta-data. This is printed
-        to the console with self.center_print().
+        str representation of the quote meta-data.
 
         :param self -> ``QuoteDisplayer``:
         """
@@ -46,8 +54,7 @@ class QuoteDisplayer(Displayer):
             s += self.__repr__(key, value)
         return s
 
-    @staticmethod    
-    def __repr__(key: str, value: Any) -> str:
+    def __repr__(self, key: str, value: Any) -> str:
         """
         builds a string representation of a key-value pair of EquityMeta.
 
@@ -56,4 +63,7 @@ class QuoteDisplayer(Displayer):
 
         :returns result -> ``str``: a string representation of the key-value pair.
         """
-        return f"{key}: {value}\n"
+        formatted_key = self.set_formatting(key, "bold")
+        formatted_value = self.set_formatting(value, ["color", "bold", "underline"])
+        result = self.set_formatting(f"{formatted_key}: {formatted_value}\n", "align")
+        return result

--- a/equit_ease/displayer/format.py
+++ b/equit_ease/displayer/format.py
@@ -23,7 +23,14 @@ class Formatter:
         :returns result -> ``str`` or ``int``: the 'colorized' value
         """
         strinigified_value = str(a_value)
-        return Colors.RED + strinigified_value + Colors.END
+
+        if isinstance(a_value, (int, float)):
+            if a_value >= 0:
+                return Colors.GREEN + strinigified_value + Colors.END
+            else:
+                return Colors.RED + strinigified_value + Colors.END
+        else:
+            return Colors.GREEN + strinigified_value + Colors.END
     
     @staticmethod
     def set_size_for():

--- a/equit_ease/displayer/format.py
+++ b/equit_ease/displayer/format.py
@@ -1,0 +1,45 @@
+import os
+
+from equit_ease.utils.Colors import Colors
+
+class Formatter:
+    """defines methods related to the formatting of string or integer data."""
+
+    @staticmethod
+    def bold(a_value: str or int) -> str:
+        """
+        bold a string or integer data type.
+        :param a_value: ``str`` or ``int``: the value to bold.
+        :return -> ``str`` or ``int``: the bolded value.
+        """
+        return Colors.BOLD + str(a_value) + Colors.END
+    
+    @staticmethod
+    def set_color_for(a_value: str or int) -> str or int:
+        """
+        set the color of a string or integer.
+
+        :param a_value -> ``str`` or ``int``: the value to 'colorize'.
+        :returns result -> ``str`` or ``int``: the 'colorized' value
+        """
+        strinigified_value = str(a_value)
+        return Colors.RED + strinigified_value + Colors.END
+    
+    @staticmethod
+    def set_size_for():
+        return
+    
+    @staticmethod
+    def underline(a_value):
+        return Colors.UNDERLINE + str(a_value) + Colors.END
+    
+    @staticmethod
+    def align(string_to_center: str) -> str:
+        """
+        returns a center-aligned string to the console.
+
+        :param string_to_center -> ``str``: the string to print to the console.
+        :returns result -> ``str``:
+        """
+        result = "{:>12}".format(string_to_center)
+        return result

--- a/equit_ease/utils/Colors.py
+++ b/equit_ease/utils/Colors.py
@@ -1,0 +1,7 @@
+
+class Colors:
+    BOLD = '\033[1m'
+    RED = '\033[91m'
+    GREEN = '\033[92m'
+    END = '\033[0m'
+    UNDERLINE = '\033[4m'

--- a/equit_ease/utils/Constants.py
+++ b/equit_ease/utils/Constants.py
@@ -1,3 +1,5 @@
+from equit_ease.displayer.format import Formatter
+
 class Constants:
     """Dedicated to storing any constants used throughout this program in a centralized location."""
 
@@ -24,6 +26,13 @@ class Constants:
         "dividendDate",
     ]
 
+    dispatcher = {
+        'bold': Formatter.bold,
+        'color': Formatter.set_color_for,
+        'underline': Formatter.underline,
+        "align": Formatter.align
+    }
+
     # intermediary data struct used to map yahoo finance columns -> dataclass names.
     yahoo_finance_column_mappings = {
         "previous_close": "regularMarketPreviousClose",
@@ -45,5 +54,4 @@ class Constants:
         "next_dividend_date": "dividendDate",
     }
 
-    # def build_kw_args()
     # https://query1.finance.yahoo.com/v8/finance/chart/T?region=US&lang=en-US&includePrePost=false&interval=1d&range=6mo

--- a/main.py
+++ b/main.py
@@ -1,15 +1,25 @@
 from equit_ease.reader.read import Reader
-from equit_ease.parser.parse import Parser
+from equit_ease.parser.parse import QuoteParser, ChartParser
+from equit_ease.displayer.display import Displayer, QuoteDisplayer, ChartDisplayer
 
-reader = Reader("F")
+from pyfiglet import Figlet
+import os
 
+fig = Figlet()
+reader = Reader("MSFT")
 reader.build_equity_quote_url
 reader.build_equity_chart_url
-
 equity_quote_data = reader.get_equity_quote_data()
 equity_chart_data = reader.get_equity_chart_data()
 
-parser = Parser(equity_to_search=reader.equity_to_search, quote_data=equity_quote_data, chart_data=equity_chart_data)
-print(parser.extract_equity_meta_data())
-# parser.extract_equity_chart_data()
-# print(Parser.__mro__)
+quote_parser = QuoteParser(equity_to_search=reader.equity_to_search, data=equity_quote_data)
+chart_parser = ChartParser(equity_to_search=reader.equity_to_search, data=equity_chart_data)
+quote_data = quote_parser.extract_equity_meta_data()
+chart_data = chart_parser.extract_equity_chart_data()
+
+title = fig.renderText(reader.equity_to_search)
+displayer = QuoteDisplayer(reader.equity_to_search, quote_data)
+stringified_representation = displayer.stringify()
+quote_contents = stringified_representation.split("\n")
+[print(line.center(os.get_terminal_size().columns)) for line in title.split("\n")]
+print("\n\t".join(line  for line in quote_contents))

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ pathspec==0.8.1
 pluggy==0.13.1
 py==1.10.0
 pycodestyle==2.6.0
+pyfiglet==0.8.post1
 pyparsing==2.4.7
-pytest==6.2.1
 regex==2020.11.13
 requests==2.25.1
 toml==0.10.2


### PR DESCRIPTION
- `Formatter` class for mapping ANSI color codes onto string values
- Specify ANSI color codes in the utils/Colors.py file
- add functionality for applying one or many styles to a string in `display.py`
- very simple logic for displaying red-vs-green text.

Pyfiglet is added as a new dependency, but this is a tentative fix.

Overall
===
`QuoteMeta` mapping of data -> console is done.
Next: `ChartMeta`.