### PR TITLE
Add chart logging functionality

### DIFF
--- a/equit_ease/displayer/display.py
+++ b/equit_ease/displayer/display.py
@@ -47,24 +47,31 @@ class ChartDisplayer(Displayer):
         """builds the axes and core plot for the chart."""
         
         plot = []
-        n_columns = (3*os.get_terminal_size().columns)//4
-        n_rows = os.get_terminal_size().lines//2
+        n_columns = (3*os.get_terminal_size().columns) // 4
+        n_rows = (os.get_terminal_size().lines) // 2
 
         x_axis_labels = self._build_x_axis_labels(n_columns, range(n_columns)[0], range(n_columns)[len(range(n_columns))//4], range(n_columns)[len(range(n_columns))//2], range(n_columns)[(3*len(range(n_columns)))//4], range(n_columns)[len(range(n_columns)) - 1])
+        y_axis_labels = self._build_y_axis_labels(n_rows, range(n_rows)[0], range(n_rows)[len(range(n_rows))//4], range(n_rows)[len(range(n_rows))//2], range(n_rows)[(3*len(range(n_rows)))//4], range(n_rows)[len(range(n_rows)) - 1])[::-1]
+        padded_y_axis_labels = self._set_padding(y_axis_labels)
+        max_width = len(max(y_axis_labels, key=len))
+        padded_x_axis_labels = max_width*" " + x_axis_labels
         
-        plot = self._build_plot(len(x_axis_labels), n_rows, "-", "|")
+        plot = self._build_plot(len(x_axis_labels), n_rows, "_", "|")
+        plot.append(padded_x_axis_labels)
 
-        for line in plot:
-            print(line)
-        print(x_axis_labels)
+        for i, line in enumerate(plot):
+            if isinstance(line, list):
+                line.insert(0, padded_y_axis_labels[i])
+            print("".join(line))
 
-    def _build_x_axis_labels(self, n_columns: int, *args: str) -> List[str]:
+    def _build_x_axis_labels(self, n_columns: int, *args: str) -> str:
         """
         build x axis labels for the plot.
 
+        :param n_columns -> ``int``: the number of columns in the plot.
         :args -> ``str``: should contain the indices on which the labels should be placed.
 
-        :returns result -> ``List[str]``: a formatted list of x-axis labels
+        :returns result -> ``str``: a formatted list of x-axis labels
         """
         labels = [" "]*n_columns
         axes_len = len(self.x_axes)
@@ -76,15 +83,54 @@ class ChartDisplayer(Displayer):
         l = [min, q_one, q_two, q_three, max]
 
         for i, arg in enumerate(args):
-            # labels[arg] = datetime.fromtimestamp(l[i]).strftime("%H:%M")
             labels[arg] = datetime.fromtimestamp(l[i]).strftime("%H")
         
         return "".join(labels)
 
 
     
-    def build_y_axes():
-        """"""
+    def _build_y_axis_labels(self, n_rows: int, *args: str) -> str:
+        """
+        build y axis for the plot.
+        
+        :param n_rows: -> the number of rows in the plot.
+        :args -> ``str``: should contain the indices on which the labels should be placed.
+        """
+        labels = [" "]*n_rows
+        axes_len = len(self.y_axes)
+        min = sorted(self.y_axes)[0]
+        q_one = sorted(self.y_axes)[axes_len // 4]
+        q_two = sorted(self.y_axes)[axes_len // 2]
+        q_three = sorted(self.y_axes)[ (3*axes_len) // 4]
+        max = sorted(self.y_axes)[axes_len - 1]
+        l = [min, q_one, q_two, q_three, max]
+
+        for i, arg in enumerate(args):
+            labels[arg] = str(l[i])
+        
+        return labels
+
+    @staticmethod
+    def _set_padding(labels: List[str]):
+        """
+        adds whitespace along the y-axis to align labels.
+        
+        :param labels -> ``List[str]``: the labels for the y axis of the plot.
+
+        :returns result -> ``List[str]``:  padded y axis labels.
+        """
+        max_width = len(max(labels, key=len))
+        padded_labels = []
+
+        for label in labels:
+            label_length_diff = max_width - len(label)
+            padding = " "*label_length_diff
+            padded_label = padding + label + " "
+            padded_labels.append(padded_label)
+        
+        return padded_labels
+
+
     
     @staticmethod
     def _build_plot(x_axis: int, y_axis: int, x_axis_pattern: str, y_axis_pattern: str) -> List[List[str]]:
@@ -109,7 +155,7 @@ class ChartDisplayer(Displayer):
                         x_axis_values.append(y_axis_pattern)
                     else:
                         x_axis_values.append(" ")
-            plot.append("".join(x_axis_values))
+            plot.append(x_axis_values)
         
         return plot
 

--- a/equit_ease/displayer/display.py
+++ b/equit_ease/displayer/display.py
@@ -72,14 +72,6 @@ class ChartDisplayer(Displayer):
         :returns result -> ``str``: a formatted list of x-axis labels
         """
         labels = [" "]*n_columns
-        # axes_len = len(self.x_axes)
-        # min = self.x_axes[0]
-        # q_one = self.x_axes[axes_len // 4]
-        # q_two = self.x_axes[axes_len // 2]
-        # q_three = self.x_axes[ (3*axes_len) // 4]
-        # max = self.x_axes[axes_len - 1]
-        # l = [min, q_one, q_two, q_three, max]
-
         five_num_summary = self._build_five_num_summary(self.x_axes)
 
         for i, arg in enumerate(args):

--- a/equit_ease/displayer/display.py
+++ b/equit_ease/displayer/display.py
@@ -52,8 +52,8 @@ class ChartDisplayer(Displayer):
 
         x_axis_labels = self._build_x_axis_labels(n_columns, range(n_columns)[0], range(n_columns)[len(range(n_columns))//4], range(n_columns)[len(range(n_columns))//2], range(n_columns)[(3*len(range(n_columns)))//4], range(n_columns)[len(range(n_columns)) - 1])
         y_axis_labels = self._build_y_axis_labels(n_rows, range(n_rows)[0], range(n_rows)[len(range(n_rows))//4], range(n_rows)[len(range(n_rows))//2], range(n_rows)[(3*len(range(n_rows)))//4], range(n_rows)[len(range(n_rows)) - 1])[::-1]
-        padded_y_axis_labels = self._set_padding(y_axis_labels)
         max_width = len(max(y_axis_labels, key=len))
+        padded_y_axis_labels = self._set_padding(y_axis_labels, max_width)
         padded_x_axis_labels = max_width*" " + x_axis_labels
         
         plot = self._build_plot(len(x_axis_labels), n_rows, "_", "|")
@@ -111,7 +111,7 @@ class ChartDisplayer(Displayer):
         return labels
 
     @staticmethod
-    def _set_padding(labels: List[str]):
+    def _set_padding(labels: List[str], max_width: int):
         """
         adds whitespace along the y-axis to align labels.
         
@@ -119,7 +119,6 @@ class ChartDisplayer(Displayer):
 
         :returns result -> ``List[str]``:  padded y axis labels.
         """
-        max_width = len(max(labels, key=len))
         padded_labels = []
 
         for label in labels:

--- a/equit_ease/displayer/display.py
+++ b/equit_ease/displayer/display.py
@@ -37,6 +37,10 @@ class Displayer(Parser):
 class ChartDisplayer(Displayer):
     """"contains methods used solely for the displayment of the chart data."""
 
+    def _set_graph_axes(self):
+        """builds the axes and core plot for the chart."""
+        return self.data
+
 
 class QuoteDisplayer(Displayer):
     """contains methods used solely for the displayment of quote data."""

--- a/equit_ease/displayer/display.py
+++ b/equit_ease/displayer/display.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import math
+from datetime import datetime
 import os
 from statistics import quantiles
 import dataclasses
@@ -45,41 +45,64 @@ class ChartDisplayer(Displayer):
 
     def _set_graph_axes(self):
         """builds the axes and core plot for the chart."""
-        x_axis_range = list(range(*self.x_axes))
-        y_axis_range = list(range(*self.y_axes))
         
         plot = []
-        n_columns = (2*os.get_terminal_size().columns)//4
+        n_columns = (3*os.get_terminal_size().columns)//4
         n_rows = os.get_terminal_size().lines//2
 
-        plot = self._build_plot(n_columns, n_rows, "-", "|")
+        x_axis_labels = self._build_x_axis_labels(n_columns, range(n_columns)[0], range(n_columns)[len(range(n_columns))//4], range(n_columns)[len(range(n_columns))//2], range(n_columns)[(3*len(range(n_columns)))//4], range(n_columns)[len(range(n_columns)) - 1])
+        
+        plot = self._build_plot(len(x_axis_labels), n_rows, "-", "|")
 
-        # return len(plot), len(plot[0])
         for line in plot:
             print(line)
+        print(x_axis_labels)
 
-    
-    def build_x_axes():
-        """"""
+    def _build_x_axis_labels(self, n_columns: int, *args: str) -> List[str]:
+        """
+        build x axis labels for the plot.
+
+        :args -> ``str``: should contain the indices on which the labels should be placed.
+
+        :returns result -> ``List[str]``: a formatted list of x-axis labels
+        """
+        labels = [" "]*n_columns
+        axes_len = len(self.x_axes)
+        min = self.x_axes[0]
+        q_one = self.x_axes[axes_len // 4]
+        q_two = self.x_axes[axes_len // 2]
+        q_three = self.x_axes[ (3*axes_len) // 4]
+        max = self.x_axes[axes_len - 1]
+        l = [min, q_one, q_two, q_three, max]
+
+        for i, arg in enumerate(args):
+            # labels[arg] = datetime.fromtimestamp(l[i]).strftime("%H:%M")
+            labels[arg] = datetime.fromtimestamp(l[i]).strftime("%H")
+        
+        return "".join(labels)
+
 
     
     def build_y_axes():
         """"""
     
     @staticmethod
-    def _build_plot(x_axis: int, y_axis: int, x_axis_pattern: str, y_axis_pattern: str) -> List[List[Any]]:
+    def _build_plot(x_axis: int, y_axis: int, x_axis_pattern: str, y_axis_pattern: str) -> List[List[str]]:
         """
         build plot used to display price/volume data.
 
-        :param x_axis -> ``int``: the number of rows
-        :param y_axis -> ``int``:
-        :param axes_pattern: ``str``:
+        :param x_axis -> ``int``: the number of columns for the plot
+        :param y_axis -> ``int``: the number of lines for the plot
+        :param x_axis_pattern: ``str``: the pattern to use for drawing the x axis
+        :param y_axis_pattern: ``str``: the pattern to use for drawing the y axis
+
+        :returns plot -> ``List[str]``: the plot represented as a one-dimensional array.
         """
         plot = []
         for i in range(y_axis):
             x_axis_values = []
             for j in range(x_axis):
-                if i ==  0 or i == max(range((y_axis))):
+                if i ==  0 or i == max(range(y_axis)):
                     x_axis_values.append(x_axis_pattern)
                 else:
                     if j == 0 or j == max(range(x_axis)):

--- a/equit_ease/displayer/display.py
+++ b/equit_ease/displayer/display.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
+import math
 import os
+from statistics import quantiles
 import dataclasses
-from typing import Any
+from typing import Any, List
 
 from equit_ease.datatypes.equity_meta import EquityMeta
 from equit_ease.parser.parse import Parser
@@ -36,10 +38,26 @@ class Displayer(Parser):
 
 class ChartDisplayer(Displayer):
     """"contains methods used solely for the displayment of the chart data."""
+    def __init__(self, x_axes, y_axes, title):
+        self.x_axes = x_axes
+        self.y_axes = y_axes
+        self.title = title
 
     def _set_graph_axes(self):
         """builds the axes and core plot for the chart."""
-        return self.data
+        x_axis_range = list(range(*self.x_axes))
+        y_axis_range = list(range(*self.y_axes))
+
+        # print(quantiles(y_axis_range, n=4))
+        # print(len(x_axis_range), len(y_axis_range))
+
+        data = ['-' for _ in x_axis_range]
+
+        col_width = max(len(row) for row in data) + 2  # padding
+        for row in data:
+            print("".join(row.ljust(col_width)))
+
+
 
 
 class QuoteDisplayer(Displayer):

--- a/equit_ease/displayer/display.py
+++ b/equit_ease/displayer/display.py
@@ -48,8 +48,10 @@ class ChartDisplayer(Displayer):
         plot = []
         n_columns = (3*os.get_terminal_size().columns) // 4
         n_rows = (os.get_terminal_size().lines) // 2
+        
         x_axis_labels = self._build_x_axis_labels(n_columns, *self._build_five_num_summary(n_columns))
         y_axis_labels = self._build_y_axis_labels(n_rows, *self._build_five_num_summary(n_rows))[::-1]
+        
         max_width = len(max(y_axis_labels, key=len))
         padded_y_axis_labels = self._set_padding(y_axis_labels, max_width)
         padded_x_axis_labels = max_width*" " + x_axis_labels
@@ -89,16 +91,10 @@ class ChartDisplayer(Displayer):
         :args -> ``str``: should contain the indices on which the labels should be placed.
         """
         labels = [" "]*n_rows
-        axes_len = len(self.y_axes)
-        min = sorted(self.y_axes)[0]
-        q_one = sorted(self.y_axes)[axes_len // 4]
-        q_two = sorted(self.y_axes)[axes_len // 2]
-        q_three = sorted(self.y_axes)[ (3*axes_len) // 4]
-        max = sorted(self.y_axes)[axes_len - 1]
-        l = [min, q_one, q_two, q_three, max]
+        five_num_summary = self._build_five_num_summary(sorted(self.y_axes))
 
         for i, arg in enumerate(args):
-            labels[arg] = str(l[i])
+            labels[arg] = str(five_num_summary[i])
         
         return labels
 

--- a/equit_ease/displayer/display.py
+++ b/equit_ease/displayer/display.py
@@ -49,7 +49,7 @@ class ChartDisplayer(Displayer):
         n_columns = (3*os.get_terminal_size().columns) // 4
         n_rows = (os.get_terminal_size().lines) // 2
         x_axis_labels = self._build_x_axis_labels(n_columns, *self._build_five_num_summary(n_columns))
-        y_axis_labels = self._build_y_axis_labels(n_rows, range(n_rows)[0], range(n_rows)[len(range(n_rows))//4], range(n_rows)[len(range(n_rows))//2], range(n_rows)[(3*len(range(n_rows)))//4], range(n_rows)[len(range(n_rows)) - 1])[::-1]
+        y_axis_labels = self._build_y_axis_labels(n_rows, *self._build_five_num_summary(n_rows))[::-1]
         max_width = len(max(y_axis_labels, key=len))
         padded_y_axis_labels = self._set_padding(y_axis_labels, max_width)
         padded_x_axis_labels = max_width*" " + x_axis_labels
@@ -72,16 +72,18 @@ class ChartDisplayer(Displayer):
         :returns result -> ``str``: a formatted list of x-axis labels
         """
         labels = [" "]*n_columns
-        axes_len = len(self.x_axes)
-        min = self.x_axes[0]
-        q_one = self.x_axes[axes_len // 4]
-        q_two = self.x_axes[axes_len // 2]
-        q_three = self.x_axes[ (3*axes_len) // 4]
-        max = self.x_axes[axes_len - 1]
-        l = [min, q_one, q_two, q_three, max]
+        # axes_len = len(self.x_axes)
+        # min = self.x_axes[0]
+        # q_one = self.x_axes[axes_len // 4]
+        # q_two = self.x_axes[axes_len // 2]
+        # q_three = self.x_axes[ (3*axes_len) // 4]
+        # max = self.x_axes[axes_len - 1]
+        # l = [min, q_one, q_two, q_three, max]
+
+        five_num_summary = self._build_five_num_summary(self.x_axes)
 
         for i, arg in enumerate(args):
-            labels[arg] = datetime.fromtimestamp(l[i]).strftime("%H")
+            labels[arg] = datetime.fromtimestamp(five_num_summary[i]).strftime("%H")
         
         return "".join(labels)
 
@@ -162,13 +164,13 @@ class ChartDisplayer(Displayer):
 
         :returns result -> ``Tuple``: five-number summary from min -> max.
         """
-        range_for_data = range(data)
+        range_for_data = range(data) if isinstance(data, int) else data
 
-        def get_min(data: List or Tuple or Set) -> int:
+        def get_min() -> int:
             """retrieve the minimum from the data."""
             return range_for_data[0]
         
-        def get_max(data: List or Tuple or Set) -> int:
+        def get_max() -> int:
             """retrieve the maximum from the data."""
             return range_for_data[-1]
         
@@ -185,11 +187,11 @@ class ChartDisplayer(Displayer):
                     return range_for_data[(3*len(range_for_data)) // 4]
         
         return (
-            get_min(data),
+            get_min(),
             get_quartile(1),
             get_quartile(2),
             get_quartile(3),
-            get_max(data)
+            get_max()
         )
 
     

--- a/equit_ease/displayer/display.py
+++ b/equit_ease/displayer/display.py
@@ -47,17 +47,48 @@ class ChartDisplayer(Displayer):
         """builds the axes and core plot for the chart."""
         x_axis_range = list(range(*self.x_axes))
         y_axis_range = list(range(*self.y_axes))
+        
+        plot = []
+        n_columns = (2*os.get_terminal_size().columns)//4
+        n_rows = os.get_terminal_size().lines//2
 
-        # print(quantiles(y_axis_range, n=4))
-        # print(len(x_axis_range), len(y_axis_range))
+        plot = self._build_plot(n_columns, n_rows, "-", "|")
 
-        data = ['-' for _ in x_axis_range]
+        # return len(plot), len(plot[0])
+        for line in plot:
+            print(line)
 
-        col_width = max(len(row) for row in data) + 2  # padding
-        for row in data:
-            print("".join(row.ljust(col_width)))
+    
+    def build_x_axes():
+        """"""
 
+    
+    def build_y_axes():
+        """"""
+    
+    @staticmethod
+    def _build_plot(x_axis: int, y_axis: int, x_axis_pattern: str, y_axis_pattern: str) -> List[List[Any]]:
+        """
+        build plot used to display price/volume data.
 
+        :param x_axis -> ``int``: the number of rows
+        :param y_axis -> ``int``:
+        :param axes_pattern: ``str``:
+        """
+        plot = []
+        for i in range(y_axis):
+            x_axis_values = []
+            for j in range(x_axis):
+                if i ==  0 or i == max(range((y_axis))):
+                    x_axis_values.append(x_axis_pattern)
+                else:
+                    if j == 0 or j == max(range(x_axis)):
+                        x_axis_values.append(y_axis_pattern)
+                    else:
+                        x_axis_values.append(" ")
+            plot.append("".join(x_axis_values))
+        
+        return plot
 
 
 class QuoteDisplayer(Displayer):

--- a/equit_ease/parser/parse.py
+++ b/equit_ease/parser/parse.py
@@ -115,23 +115,21 @@ class ChartParser(Parser):
         is then used to build a graphical representation of the stock price and/or
         volume (x-axis is time, y-axis is price | volume)
         """
-        equity_chart_data = self.data
+        equity_chart_data = self.data["chart"]["result"][0]
 
-        json_data_for_extraction = equity_chart_data["chart"]["result"][0][
-            "indicators"
-        ]["quote"][0]
+        json_data_for_extraction = equity_chart_data["indicators"]["quote"][0]
 
-        json_timezone_for_extraction = equity_chart_data["chart"]["result"][0]
         keys_to_extract = json_data_for_extraction.keys()
 
         equity_chart_data_struct = self._build_dict_repr(
             keys_to_extract, json_data_for_extraction
         )
+
         return (
             self._standardize(self._extract_data_from(equity_chart_data_struct, "low")),
             self._standardize(self._extract_data_from(equity_chart_data_struct, "high")),
             self._standardize(self._extract_data_from(equity_chart_data_struct, "open")),
             self._standardize(self._extract_data_from(equity_chart_data_struct, "close")),
             self._standardize(self._extract_data_from(equity_chart_data_struct, "volume")),
-            self._standardize(self._extract_data_from(json_timezone_for_extraction, "timestamp")),
+            self._standardize(self._extract_data_from(equity_chart_data, "timestamp")), # extract from base equity chart data
         )

--- a/equit_ease/parser/parse.py
+++ b/equit_ease/parser/parse.py
@@ -120,6 +120,8 @@ class ChartParser(Parser):
         json_data_for_extraction = equity_chart_data["chart"]["result"][0][
             "indicators"
         ]["quote"][0]
+
+        json_timezone_for_extraction = equity_chart_data["chart"]["result"][0]
         keys_to_extract = json_data_for_extraction.keys()
 
         equity_chart_data_struct = self._build_dict_repr(
@@ -131,4 +133,5 @@ class ChartParser(Parser):
             self._standardize(self._extract_data_from(equity_chart_data_struct, "open")),
             self._standardize(self._extract_data_from(equity_chart_data_struct, "close")),
             self._standardize(self._extract_data_from(equity_chart_data_struct, "volume")),
+            self._standardize(self._extract_data_from(json_timezone_for_extraction, "timestamp")),
         )

--- a/equit_ease/parser/parse.py
+++ b/equit_ease/parser/parse.py
@@ -97,6 +97,7 @@ class ChartParser(Parser):
         
         :returns result -> ``List[float]``
         """
+        # TODO: can I do this more cleanly?
         remove_none_types = [
             item for item in item_to_standardize if item is not None
         ]

--- a/main.py
+++ b/main.py
@@ -6,20 +6,30 @@ from pyfiglet import Figlet
 import os
 
 fig = Figlet()
-reader = Reader("MSFT")
-reader.build_equity_quote_url
-reader.build_equity_chart_url
+reader = Reader("CRM")
+reader.build_company_lookup_url()
+long_name, ticker = reader.get_equity_company_data()
+reader.ticker = ticker
+reader.name = long_name
+
+print(reader.ticker, " | ", reader.name)
+
+reader.build_equity_quote_url()
+reader.build_equity_chart_url()
+
 equity_quote_data = reader.get_equity_quote_data()
 equity_chart_data = reader.get_equity_chart_data()
 
-quote_parser = QuoteParser(equity_to_search=reader.equity_to_search, data=equity_quote_data)
-chart_parser = ChartParser(equity_to_search=reader.equity_to_search, data=equity_chart_data)
+quote_parser = QuoteParser(equity=reader.equity, data=equity_quote_data)
+chart_parser = ChartParser(equity=reader.equity, data=equity_chart_data)
 quote_data = quote_parser.extract_equity_meta_data()
-chart_data = chart_parser.extract_equity_chart_data()
+low_equity_data, high_equity_data, open_equity_data, close_equity_data, volume_equity_data = chart_parser.extract_equity_chart_data()
 
-title = fig.renderText(reader.equity_to_search)
-displayer = QuoteDisplayer(reader.equity_to_search, quote_data)
-stringified_representation = displayer.stringify()
-quote_contents = stringified_representation.split("\n")
-[print(line.center(os.get_terminal_size().columns)) for line in title.split("\n")]
-print("\n\t".join(line  for line in quote_contents))
+# title = fig.renderText(reader.name)
+# displayer = QuoteDisplayer(reader.equity, quote_data)
+# stringified_representation = displayer.stringify()
+# quote_contents = stringified_representation.split("\n")
+# [print(line.center(os.get_terminal_size().columns)) for line in title.split("\n")]
+# print("\n\t".join(line  for line in quote_contents))
+
+print(min(low_equity_data), max(high_equity_data))


### PR DESCRIPTION
A chart is now mapped to the terminal with an x-axis that contains the `time` and a y-axis that contains the `price` or `volume` of the stock. 

The chart is built as a multi-dimensional list. The multi-dimensional list is first empty but is then one-by-one replaced with labels, the plot itself, and then (next) the data points to display. This process takes around .2 seconds right now

The chart is dynamically sized to fit the terminal screen, and padding is also added around axes to try and make the plot easier to interpret.